### PR TITLE
Separate topic page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,25 +66,25 @@ export default function App() {
           />
 
           <Route path="*" element={<NotFoundPage />} />
+
+          <Route
+            path={ROUTES.LOGIN}
+            element={
+              <PublicRoute>
+                <LoginPage />
+              </PublicRoute>
+            }
+          />
+
+          <Route
+            path={ROUTES.REGISTER}
+            element={
+              <PublicRoute>
+                <RegisterPage />
+              </PublicRoute>
+            }
+          />
         </Route>
-
-        <Route
-          path={ROUTES.LOGIN}
-          element={
-            <PublicRoute>
-              <LoginPage />
-            </PublicRoute>
-          }
-        />
-
-        <Route
-          path={ROUTES.REGISTER}
-          element={
-            <PublicRoute>
-              <RegisterPage />
-            </PublicRoute>
-          }
-        />
       </Routes>
 
       <ToastContainer

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import NotFoundPage from './pages/NotFoundPage/NotFoundPage';
 import ProfilePage from './pages/ProfilePage/ProfilePage';
 import ProgressPage from './pages/ProgressPage/ProgressPage';
 import RegisterPage from './pages/RegisterPage/RegisterPage';
+import TopicPage from './pages/TopicPage/TopicPage';
 import { login } from './redux/slices/authSlice';
 import { getAccessToken } from './utils/tokenStorage';
 
@@ -61,6 +62,15 @@ export default function App() {
             element={
               <ProtectedRoute>
                 <ProfilePage />
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path={ROUTES.TOPIC}
+            element={
+              <ProtectedRoute>
+                <TopicPage />
               </ProtectedRoute>
             }
           />

--- a/src/api/knowledgeApi.ts
+++ b/src/api/knowledgeApi.ts
@@ -1,0 +1,13 @@
+import type { Topic, TopicPreview } from '@/ts/interfaces';
+
+import { api } from './axiosInstance';
+
+export const getTopics = async (): Promise<Topic[]> => {
+  const response = await api.get<Topic[]>('/knowledge/topics');
+  return response.data;
+};
+
+export const getTopicPreview = async (topicId: string): Promise<TopicPreview> => {
+  const response = await api.get<TopicPreview>(`/knowledge/topics/${topicId}/preview`);
+  return response.data;
+};

--- a/src/components/AIAssistant/AIAssistantModal/AIAssistantModal.tsx
+++ b/src/components/AIAssistant/AIAssistantModal/AIAssistantModal.tsx
@@ -31,9 +31,10 @@ export const AIAssistantModal = ({ isOpen, onClose }: AIModalProps) => {
     if (!input.trim()) return;
 
     const userId = crypto.randomUUID();
+    const userInput = input;
 
-    await sendMessage(input, userId);
     setInput('');
+    await sendMessage(userInput, userId);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/forms/LoginForm/LoginForm.module.scss
+++ b/src/components/forms/LoginForm/LoginForm.module.scss
@@ -1,10 +1,9 @@
-@use '@/styles/variables' as *;
+@use "@/styles/variables" as *;
 
 .form {
   max-width: 400px;
   width: 90%;
   margin: auto;
-  margin-top: 50px;
   padding: 32px;
   display: flex;
   flex-direction: column;

--- a/src/components/forms/RegisterForm/RegisterForm.module.scss
+++ b/src/components/forms/RegisterForm/RegisterForm.module.scss
@@ -1,10 +1,9 @@
-@use '@/styles/variables' as *;
+@use "@/styles/variables" as *;
 
 .form {
   max-width: 400px;
   width: 90%;
   margin: auto;
-  margin-top: 50px;
   padding: 32px;
   display: flex;
   flex-direction: column;

--- a/src/components/ui/Button/Button.module.scss
+++ b/src/components/ui/Button/Button.module.scss
@@ -30,7 +30,8 @@
     color: var(--btn-primary-text);
     background-color: var(--btn-primary-bg);
 
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled),
+    &.active {
       background-color: var(--btn-primary-bg-hover);
     }
 
@@ -45,7 +46,8 @@
     background-color: var(--btn-secondary-bg);
     border-color: var(--btn-secondary-border);
 
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled),
+    &.active {
       color: var(--btn-secondary-text-hover);
       background-color: var(--btn-secondary-bg-hover);
       border-color: transparent;

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -6,6 +6,7 @@ import styles from './Button.module.scss';
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary';
   size?: 'md' | 'sm';
+  isActive?: boolean;
 }
 
 function Button({
@@ -13,13 +14,22 @@ function Button({
   variant = 'primary',
   size = 'md',
   type = 'button',
+  isActive = false,
   children,
   ...props
 }: ButtonProps) {
   return (
     <button
       type={type}
-      className={clsx(styles.button, styles[variant], styles[size], className)}
+      className={clsx(
+        styles.button,
+        styles[variant],
+        styles[size],
+        {
+          [styles.active]: isActive,
+        },
+        className,
+      )}
       {...props}
     >
       {children}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ const ROUTES = {
   PROGRESS: '/progress',
   INTERVIEW: '/interview',
   PROFILE: '/profile',
+  TOPIC: '/topics/:slug',
 };
 
 export { ROUTES };

--- a/src/hooks/useTopicPreview.ts
+++ b/src/hooks/useTopicPreview.ts
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+import { toastError, toastLoading, toastSuccess } from '@/utils/toast';
+
+import type { ApiError, TopicPreview } from '@/ts/interfaces';
+
+import { getTopicPreview } from '@/api/knowledgeApi';
+
+export const useTopicPreview = (topicId: string): TopicPreview | null => {
+  const [topic, setTopic] = useState<TopicPreview | null>(null);
+
+  useEffect(() => {
+    if (!topicId) return;
+
+    const fetchTopic = async () => {
+      const toastId = toastLoading('Loading topic...');
+
+      try {
+        const data = await getTopicPreview(topicId);
+        setTopic(data);
+        toastSuccess(toastId, 'Topic loaded successfully 🎉');
+      } catch (error) {
+        if (axios.isAxiosError<ApiError>(error)) {
+          toastError(toastId, error.response?.data?.message || 'Failed to load topic');
+        } else {
+          toastError(toastId, 'Unexpected error occurred');
+        }
+      }
+    };
+
+    void fetchTopic();
+  }, [topicId]);
+
+  return topic;
+};

--- a/src/hooks/useTopics.ts
+++ b/src/hooks/useTopics.ts
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+import { toastError, toastLoading, toastSuccess } from '@/utils/toast';
+
+import type { ApiError, Topic } from '@/ts/interfaces';
+
+import { getTopics } from '@/api/knowledgeApi';
+
+export const useTopics = (): Topic[] => {
+  const [topics, setTopics] = useState<Topic[]>([]);
+
+  useEffect(() => {
+    const fetchTopics = async () => {
+      const toastId = toastLoading('Loading topics...');
+
+      try {
+        const data = await getTopics();
+        setTopics(data);
+        toastSuccess(toastId, 'Topics loaded successfully 🎉');
+      } catch (error) {
+        if (axios.isAxiosError<ApiError>(error)) {
+          toastError(toastId, error.response?.data?.message || 'Failed to load topics');
+        } else {
+          toastError(toastId, 'Unexpected error occurred');
+        }
+      }
+    };
+
+    void fetchTopics();
+  }, []);
+
+  return topics;
+};

--- a/src/pages/MapPage/MapPage.tsx
+++ b/src/pages/MapPage/MapPage.tsx
@@ -1,7 +1,26 @@
+import { useNavigate } from 'react-router-dom';
+
+import { useTopics } from '@/hooks/useTopics';
+
 export default function MapPage() {
+  const topics = useTopics();
+  const navigate = useNavigate();
+
+  const openTopic = (topicId: string, slug: string) => {
+    void navigate(`/topics/${slug}`, { state: { topicId } });
+  };
+
   return (
-    <>
+    <div>
       <h1>Map Page</h1>
-    </>
+
+      <ul>
+        {topics.map((topic) => (
+          <li key={topic.id}>
+            <button onClick={() => openTopic(topic.id, topic.slug)}>{topic.title}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/src/pages/TopicPage/TopicPage.module.scss
+++ b/src/pages/TopicPage/TopicPage.module.scss
@@ -1,0 +1,92 @@
+@use '@/styles/variables' as *;
+
+.header {
+  margin-bottom: 20px;
+
+  h1 {
+    font-size: 34px;
+    font-weight: 700;
+    margin-bottom: 10px;
+  }
+
+  p {
+    font-size: 16px;
+    color: var(--color-text-muted);
+  }
+}
+
+.tabs {
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  cursor: pointer;
+  position: relative;
+  border-radius: 18px;
+  padding: 22px;
+
+  background: linear-gradient(180deg, var(--color-text-btn) 0%, rgba(255, 255, 255, 0.9) 100%);
+
+  border: 1px solid rgba(0, 0, 0, 0.04);
+
+  box-shadow:
+    0 2px 6px rgba(31, 47, 70, 0.06),
+    0 6px 14px rgba(31, 47, 70, 0.06);
+
+  transition: all 0.25s ease;
+
+  &:hover {
+    transform: translateY(-3px);
+
+    box-shadow:
+      0 6px 18px rgba(31, 47, 70, 0.08),
+      0 12px 28px rgba(31, 47, 70, 0.08);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  h3 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 14px;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    li {
+      padding: 10px 12px;
+      border-radius: 10px;
+      font-size: 16px;
+
+      transition: all 0.2s ease;
+
+      &:hover {
+        background: var(--color-surface);
+        transform: translateX(4px);
+      }
+
+      & + li {
+        margin-top: 8px;
+      }
+    }
+  }
+}

--- a/src/pages/TopicPage/TopicPage.tsx
+++ b/src/pages/TopicPage/TopicPage.tsx
@@ -1,0 +1,97 @@
+import { useLocation, useSearchParams } from 'react-router-dom';
+
+import { Container } from '@/components/Container/Container';
+import { Button, Loader } from '@/components/ui';
+
+import type { LocationState } from '@/ts/interfaces';
+import type { TabType } from '@/ts/types';
+
+import { useTopicPreview } from '@/hooks/useTopicPreview';
+
+import styles from './TopicPage.module.scss';
+
+export default function TopicPage() {
+  const location = useLocation();
+  const state = location.state as LocationState | undefined;
+  const topicId = state?.topicId;
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const tabParam = searchParams.get('tab');
+
+  const activeTab: TabType = tabParam === 'theory' || tabParam === 'code' ? tabParam : 'overview';
+
+  const setTab = (tab: TabType) => {
+    setSearchParams({ tab });
+  };
+
+  const data = useTopicPreview(topicId || '');
+
+  if (!data) return <Loader size="lg" />;
+
+  return (
+    <Container>
+      <div className={styles.header}>
+        <h1>{data.topic.title}</h1>
+        <p>Practice questions and improve your skills step by step</p>
+      </div>
+
+      <div className={styles.tabs}>
+        <Button
+          size="sm"
+          variant="secondary"
+          isActive={activeTab === 'overview'}
+          onClick={() => setSearchParams({})}
+        >
+          Overview
+        </Button>
+
+        <Button
+          size="sm"
+          variant="secondary"
+          isActive={activeTab === 'theory'}
+          onClick={() => setTab('theory')}
+        >
+          Theory Questions
+        </Button>
+
+        <Button
+          size="sm"
+          variant="secondary"
+          isActive={activeTab === 'code'}
+          onClick={() => setTab('code')}
+        >
+          Code Tasks
+        </Button>
+      </div>
+
+      {(!activeTab || activeTab === 'overview') && (
+        <div className={styles.grid}>
+          <div className={styles.card} onClick={() => setTab('theory')}>
+            <h3>Theory Questions</h3>
+            <ul>
+              {data.questions.map((task) => (
+                <li key={task.id}>{task.prompt}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div className={styles.card} onClick={() => setTab('code')}>
+            <h3>Code Tasks</h3>
+            <ul>
+              {data.codeTasks.map((task) => (
+                <li key={task.id}>{task.title}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'theory' && (
+        <div className={styles.placeholder}>Theory content loading...</div>
+      )}
+
+      {activeTab === 'code' && <div className={styles.placeholder}>Code tasks loading...</div>}
+    </Container>
+  );
+}

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -82,6 +82,39 @@ interface AIChatResponse {
   reply: string;
 }
 
+interface TopicShort {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  order: number;
+}
+
+interface Topic extends TopicShort {
+  questionsCount: number;
+  codeTasksCount: number;
+}
+
+interface Question {
+  id: string;
+  prompt: string;
+  order: number;
+}
+
+interface CodeTask {
+  id: string;
+  title: string;
+  description: string;
+  taskType: 'AI_CHECK' | 'DRAG_DROP';
+  order: number;
+}
+
+interface TopicPreview {
+  topic: TopicShort;
+  questions: Question[];
+  codeTasks: CodeTask[];
+}
+
 export type {
   AIChatRequest,
   AIChatResponse,
@@ -96,4 +129,6 @@ export type {
   RefreshResponse,
   RegisterFormInputs,
   RegisterFormProps,
+  Topic,
+  TopicPreview,
 };

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -115,6 +115,10 @@ interface TopicPreview {
   codeTasks: CodeTask[];
 }
 
+interface LocationState {
+  topicId: string;
+}
+
 export type {
   AIChatRequest,
   AIChatResponse,
@@ -124,6 +128,7 @@ export type {
   AuthResponse,
   AuthState,
   CustomAxiosRequestConfig,
+  LocationState,
   LoginFormInputs,
   LoginFormProps,
   RefreshResponse,

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -7,4 +7,6 @@ type AIModalProps = {
   onClose: () => void;
 };
 
-export type { AIModalProps, ClickProps };
+type TabType = 'theory' | 'code' | 'overview';
+
+export type { AIModalProps, ClickProps, TabType };


### PR DESCRIPTION
This pull request contains the implementation of separate topic page:
- dynamic URL according to the slug
- loading topic data and displaying it on the page
- tabs with options in the URL for switching between description, theory, and coding tasks
- for ease of testing, a list of topics is displayed on the map page

![image](https://github.com/user-attachments/assets/a5e892f8-e30b-45ec-a582-18d22b7a61ed)